### PR TITLE
Add OrganizationId to SlotsRequest + proto messages for tenant isolation (SND-325)

### DIFF
--- a/Scrips.Core/Models/Scheduling/SlotsRequest.cs
+++ b/Scrips.Core/Models/Scheduling/SlotsRequest.cs
@@ -44,4 +44,9 @@ public class SlotsRequest
     ///     SearchFromUserApp is uses when slots are search for all location.
     /// </summary>
     public bool SearchFromUserApp { get; set; }
+
+    /// <summary>
+    ///     Organization identifier for tenant isolation.
+    /// </summary>
+    public Guid OrganizationId { get; set; }
 }

--- a/Scrips.Core/Protos/AppointmentManagement.proto
+++ b/Scrips.Core/Protos/AppointmentManagement.proto
@@ -101,6 +101,7 @@ message GetAppointmentParticipantsResponse{
 
 message GetAppointmentCustomNoteRequest {
   string appointmentId=1;
+  string organizationId=2;
 }
 
 message GetAppointmentCustomNoteResponse{
@@ -137,6 +138,7 @@ message GetPractitionerAvailabilityRequest{
   string practitionerId = 1;
   TimePeriodCollectionMessage timeCollection = 2;
   string practiceId = 3;
+  string organizationId = 4;
 }
 
 message TimePeriodCollectionMessage{
@@ -483,6 +485,7 @@ message AppointmentSponsorTypeResponse{
 message GetPractitionersAvailabilityRequest{
   TimePeriodCollectionMessages data = 1;
   string practiceId = 2;
+  string organizationId = 3;
 }
 
 message Pair {


### PR DESCRIPTION
## Summary
- Add `OrganizationId` property to `SlotsRequest` for Scheduling tenant isolation
- Add `organizationId` field to 3 proto messages: `GetAppointmentCustomNoteRequest`, `GetPractitionerAvailabilityRequest`, `GetPractitionersAvailabilityRequest`

## Context
Required by [Scrips.AppointmentScheduling PR #1732](https://github.com/Scripsteam/Scrips.AppointmentScheduling/pull/1732) — the Scheduling tenant isolation fix (SND-325). Without these changes, the Scheduling service cannot thread OrganizationId through gRPC calls and slot requests.

## Test plan
- [x] Scrips.AppointmentScheduling builds and passes 250/250 tests with this submodule change
- [ ] Verify no other repos break (additive-only change — new property with default value, new proto field numbers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)